### PR TITLE
Changes to support tap layer.

### DIFF
--- a/boards/shields/toucan/toucan.dtsi
+++ b/boards/shields/toucan/toucan.dtsi
@@ -2,7 +2,7 @@
 #include <dt-bindings/zmk/input_transform.h>
 #include <dt-bindings/zmk/matrix_transform.h>
 #include <physical_layouts.dtsi>
-
+#include <dt-bindings/input/input-event-codes.h>
 
 / {
     chosen {
@@ -107,7 +107,10 @@
         compatible = "zmk,input-listener";
         status = "disabled";
         device = <&glidepoint_split>;
-        input-processors = <&zip_xy_scaler 250 100>;
+        input-processors = <
+            &zip_xy_scaler 1 4 // 2x mult seems too fast, so lowering to 0.25x
+            >;
+
         scroller {
             layers = <1 2>;
             input-processors = <
@@ -115,6 +118,24 @@
                 &zip_scroll_scaler 1 5
                 &zip_scroll_transform INPUT_TRANSFORM_X_INVERT
             >;
+        };
+
+        base {
+            layers = <0>;
+            input-processors = <
+                &touch_processor    
+            >;        
+        };        
+    };
+
+    // FIXME turn on smooth scrolling
+    input_processors {
+        touch_processor: touch_processor {
+            compatible = "zmk,input-processor-behaviors";
+            #input-processor-cells = <0>;
+ 
+            codes = <INPUT_BTN_TOUCH>;      // watch for the 'touch' pseudo button
+            bindings  = <&mo 4>;            // Activate Layer 4 while held &mo 4
         };
     };
 };

--- a/boards/shields/toucan/toucan.keymap
+++ b/boards/shields/toucan/toucan.keymap
@@ -2,11 +2,13 @@
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/pointing.h>
 
 #define BASE 0
 #define NAV  1
 #define SYM  2
 #define ADJ  3
+#define TAP  4
 
 / {
     conditional_layers {
@@ -26,7 +28,8 @@
                 &kp TAB   &kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSPC
                 &kp LCTRL &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
                 &kp LSHFT &kp Z &kp X &kp C &kp V &kp B   &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp ESC
-                                &kp LGUI &mo 1 &kp SPACE   &kp RET &mo 2 &kp RALT
+                                &kp LGUI &mo 1 &kp SPACE   &kp RET &mo 4 &kp RALT
+                                // FIXME change back to mo 2
             >;
         };
 
@@ -59,6 +62,22 @@
                                    &kp LGUI &mo NAV &kp SPACE   &kp RET &mo 2 &kp RALT
             >;
         };
+
+        tap {
+            display-name = "TAP";
+            bindings = <
+                &trans &trans &trans &trans &trans &trans   &trans &trans &trans &trans &trans &trans
+                &trans &trans &trans &trans &trans &trans   &trans &trans &trans &trans &trans &trans
+                &trans &trans &trans &trans &trans &trans   &trans &trans &trans &trans &trans &trans
+                                     &trans &trans &trans   &mkp LCLK &mkp RCLK &mkp MCLK
+            >;
+        };
+    };
+};
+
+#ifdef CONFIG_ZMK_STUDIO
+/ {
+    keymap {
         extra_1 {
                 status = "reserved";
         };
@@ -72,3 +91,4 @@
         };
     };
 };
+#endif

--- a/boards/shields/toucan/toucan_left.conf
+++ b/boards/shields/toucan/toucan_left.conf
@@ -23,3 +23,14 @@ CONFIG_ZMK_IDLE_TIMEOUT=30000
 # We use this because we need ZMK_PM, PM_DEVICE and ZMK_PM_DEVICE_SUSPEND_RESUME to get proper sleep notifications into the cirque driver
 # since we need all that might as well also turn on SOFT_OFF (which implies all these things but adds an optional SOFT_OFF feature)
 CONFIG_ZMK_PM_SOFT_OFF=y
+
+# defaults to 512 but we blow out the stack if any input-processor-behaviors is invoked
+# see https://github.com/zmkfirmware/zmk/issues/3212 for details
+CONFIG_INPUT_THREAD_STACK_SIZE=2048
+
+# enable smooth scrolling
+CONFIG_ZMK_POINTING_SMOOTH_SCROLLING=y
+
+# include zmk studio
+CONFIG_ZMK_STUDIO=y
+

--- a/boards/shields/toucan/toucan_right.conf
+++ b/boards/shields/toucan/toucan_right.conf
@@ -29,3 +29,7 @@ CONFIG_ZMK_IDLE_TIMEOUT=30000
 # We use this because we need ZMK_PM, PM_DEVICE and ZMK_PM_DEVICE_SUSPEND_RESUME to get proper sleep notifications into the cirque driver
 # since we need all that might as well also turn on SOFT_OFF (which implies all these things but adds an optional SOFT_OFF feature)
 CONFIG_ZMK_PM_SOFT_OFF=y
+
+# defaults to 512 but we blow out the stack if any input-processor-behaviors is invoked
+# see https://github.com/zmkfirmware/zmk/issues/3212 for details
+CONFIG_INPUT_THREAD_STACK_SIZE=2048

--- a/boards/shields/toucan/toucan_right.overlay
+++ b/boards/shields/toucan/toucan_right.overlay
@@ -62,8 +62,10 @@
         spi-max-frequency = <1000000>;
         status = "okay";
         dr-gpios = <&gpio0 2 (GPIO_ACTIVE_HIGH)>;
-        sensitivity = "2x";
+        sensitivity = "3x"; // 2x feels too jumpy IMO
         x-invert;
+        y-invert; // needed for abs mode?  not sure why it wasn't needed in relative
+        abs-rel-divisor = <1>;
 
         // Optional: turning this on enables very aggressive power saving, after 5 seconds with no touches
         // the trackpad will go to sleep.  It wakes up on touch, but there is a ~300ms delay.  Most users will find

--- a/config/west.yml
+++ b/config/west.yml
@@ -16,7 +16,7 @@ manifest:
       import: app/west.yml
     - name: cirque-input-module
       remote: geeksville
-      revision: toucan
+      revision: main
     - name: zmk-rgbled-widget
       remote: caksoylar
       revision: main

--- a/config/west.yml
+++ b/config/west.yml
@@ -16,7 +16,7 @@ manifest:
       import: app/west.yml
     - name: cirque-input-module
       remote: geeksville
-      revision: main
+      revision: toucan
     - name: zmk-rgbled-widget
       remote: caksoylar
       revision: main


### PR DESCRIPTION
Hi Leo,

Here's my changes to to support a 'touch' layer that activates only when there is a finger physically touching the trackpad.  I'm not sure if you'll want these changes because they slightly change the usage described in your slick preprinted keyboard layout cards.  But see the attached keymap and decide (I added a' tap' layer that just reuses the right thumb buttons as mouse buttons).  

* Add a 'tap' layer that activates only when there is a finger physically touching the trackpad (uses new cirq driver code)
* Fix a stack overflow error when using input behaviors in zmk 0.3.  See config files for link to bug.
* Change touchpad from x2 to x3 sensitivity - imo x2 felt too jumpy in actual usage on Toucan.
* Turn on zmk-studio via the config file

If you'd like to try a prebuilt binary you can use: https://github.com/geeksville/zmk-keyboard-toucan/actions/runs/21333274372

Though in practice I'm really only using 'my' normal keyboard config here: https://github.com/geeksville/zmk-urob-geeksville/actions 

Thanks for making this great keyboard!  I'll now return to happily just using it to make other code.