### PR TITLE
Update zmk-rgbled-widget revision to v0.3

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -19,6 +19,6 @@ manifest:
       revision: toucan
     - name: zmk-rgbled-widget
       remote: caksoylar
-      revision: main
+      revision: v0.3
   self:
     path: config


### PR DESCRIPTION
New commits from caksoylar will break builds unless the ZMK version is specified. "main" no longer works.