### PR TITLE
fix: raise INPUT_THREAD_STACK_SIZE to 2048

### DIFF
--- a/boards/shields/toucan/toucan_left.conf
+++ b/boards/shields/toucan/toucan_left.conf
@@ -23,3 +23,11 @@ CONFIG_ZMK_IDLE_TIMEOUT=30000
 # We use this because we need ZMK_PM, PM_DEVICE and ZMK_PM_DEVICE_SUSPEND_RESUME to get proper sleep notifications into the cirque driver
 # since we need all that might as well also turn on SOFT_OFF (which implies all these things but adds an optional SOFT_OFF feature)
 CONFIG_ZMK_PM_SOFT_OFF=y
+
+# Zephyr's default INPUT_THREAD_STACK_SIZE is 512 bytes.  On the central, every forwarded trackpad event fans out into
+# the input thread's callbacks: split_input_handler + activity_input_listener + glidepoint_listener (zip_xy_scaler ->
+# mouse HID report path -> optional scroll mapper/transform when a thumb layer is held).  That call chain blows past
+# 512 bytes within ~1.5 min of normal trackpad use — the canary is overwritten and the next nested call corrupts
+# memory adjacent to the input thread's stack, wedging the trackpad and eventually the split GATT link until the
+# right half is power-cycled.  Bumping to 2048 bytes (extra ~1.5 KB RAM, well within budget) eliminates the overflow.
+CONFIG_INPUT_THREAD_STACK_SIZE=2048

--- a/boards/shields/toucan/toucan_right.conf
+++ b/boards/shields/toucan/toucan_right.conf
@@ -29,3 +29,8 @@ CONFIG_ZMK_IDLE_TIMEOUT=30000
 # We use this because we need ZMK_PM, PM_DEVICE and ZMK_PM_DEVICE_SUSPEND_RESUME to get proper sleep notifications into the cirque driver
 # since we need all that might as well also turn on SOFT_OFF (which implies all these things but adds an optional SOFT_OFF feature)
 CONFIG_ZMK_PM_SOFT_OFF=y
+
+# Symmetric with toucan_left.conf — the central is the half that overflows because trackpad events fan out into the
+# mouse HID path there, but bumping both halves keeps the per-side stack settings consistent and costs only ~1.5 KB
+# of RAM on the peripheral, which has plenty of headroom.
+CONFIG_INPUT_THREAD_STACK_SIZE=2048


### PR DESCRIPTION
## Summary

Raises `CONFIG_INPUT_THREAD_STACK_SIZE` from Zephyr's 512-byte default to 2048 on both halves.

The central's Zephyr `input` thread runs the full forwarded-trackpad fan-out — `split_input_handler` + `activity_input_listener` + `glidepoint_listener` (`zip_xy_scaler` → mouse HID report path → optional scroll mapper). Per-thread high-water-mark instrumentation over an 81-min heavy-trackpad soak (~119k mouse HID events) measured a **peak usage of 536 bytes** on this thread — it overflows the 512-byte default (free would be -24). Raising to 2048 leaves comfortable headroom (1024 would also suffice).

The peripheral's input thread only services the local Cirque driver with no fan-out and stays well within 512; it gets the bump for symmetry (~1.5 KB RAM, well within budget).

## Note on scope

This is an independent robustness fix, **not** the right-half lock-up fix. The lock-up was a separate issue — the Cirque driver blocking the system workqueue inside `input_report(..., K_FOREVER)` — fixed in the cirque-input-module driver itself (geeksville/cirque-input-module#4). This PR stands on its own merits: the central input thread genuinely overflows the 512-byte default under real trackpad load.

## Test plan

- [x] 81-min instrumented soak; central `input` thread peak usage 536 B (no overflow at 2048); no input-thread `free=0`
- [x] Builds clean for both halves (Zephyr 3.5, ZMK v0.3)