### PR TITLE
fix: raise split_central_split_run_q stack to 4096

### DIFF
--- a/boards/shields/toucan/toucan_left.conf
+++ b/boards/shields/toucan/toucan_left.conf
@@ -23,3 +23,12 @@ CONFIG_ZMK_IDLE_TIMEOUT=30000
 # We use this because we need ZMK_PM, PM_DEVICE and ZMK_PM_DEVICE_SUSPEND_RESUME to get proper sleep notifications into the cirque driver
 # since we need all that might as well also turn on SOFT_OFF (which implies all these things but adds an optional SOFT_OFF feature)
 CONFIG_ZMK_PM_SOFT_OFF=y
+
+# The split_central_split_run_q work queue (shown as "STK ?" in stack dumps)
+# invokes zmk_behavior_invoke_binding() for every event forwarded from the
+# right half.  Its default 512-byte stack measured free=4 at HWM — one deep
+# behavior call away from silent corruption.  Under sustained hold-tap +
+# trackpad use (~31k events over ~20 min) even the 2048-byte bump reached
+# free=4 and crashed the central (right sees reason 0x08 supervision timeout).
+# Bump to 4096 to give the full hold-tap call chain headroom.
+CONFIG_ZMK_SPLIT_BLE_CENTRAL_SPLIT_RUN_STACK_SIZE=4096


### PR DESCRIPTION
## Problem

The `split_central_split_run_q` work queue on the central (left half) was crashing under sustained use.

This queue — shown as `STK ?` in stack dumps — runs `zmk_behavior_invoke_binding()` for every event forwarded from the right half. Its default 512-byte stack left only `free=4` bytes at high-water mark; one deep hold-tap behavior call would corrupt adjacent memory. Under sustained heavy use (~31k events over ~20 min with hold-tap bindings active), even a 2048-byte bump reached `free=4` and crashed the central — the right half saw `reason 0x08` (supervision timeout / `BT_HCI_ERR_CONN_TIMEOUT`) and required a manual power cycle to reconnect.

## Fix

Raise `CONFIG_ZMK_SPLIT_BLE_CENTRAL_SPLIT_RUN_STACK_SIZE` from the default 512 bytes to 4096 bytes. This gives the full hold-tap behavior call chain adequate headroom. Boot baseline after the fix: `STK ? free=3904`. Under sustained heavy use the free count stabilises and does not degrade toward 0.

## Relationship to PR #19

PR #19 fixes a separate stack overflow on the central's Zephyr `input` thread (`CONFIG_INPUT_THREAD_STACK_SIZE` 512 → 2048). This PR fixes a different thread entirely (`split_central_split_run_q`). They are independent fixes that work alongside each other — both stacks need to be raised for a fully stable central under real-world load. Neither depends on the other git-wise.

## Validation

Instrumented with `CONFIG_TOUCAN_DEBUG_INSTRUMENTATION` (USB-CDC-ACM stack HWM logging). Ran >90 minutes continuous hold-tap + trackpad use with no crashes, `STK ? free=3904` holding steady.