### PR TITLE
Add tap/hold click-and-drag on base-layer T

### DIFF
--- a/config/toucan.keymap
+++ b/config/toucan.keymap
@@ -2,6 +2,7 @@
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/pointing.h>
 
 #define BASE 0
 #define NAV  1
@@ -17,13 +18,27 @@
         };
     };
 
+    behaviors {
+        // Tap = T, hold (past 200ms) = hold left mouse button for click-and-drag.
+        // "tap-preferred" so fast typing of T never accidentally triggers a drag;
+        // the drag only engages when you deliberately hold the key.
+        tdrag: tap_t_hold_drag {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "tap-preferred";
+            tapping-term-ms = <200>;
+            bindings = <&mkp>, <&kp>;
+            display-name = "Drag/Tap";
+        };
+    };
+
     keymap {
         compatible = "zmk,keymap";
 
         base {
             display-name = "BASE";
             bindings = <
-                &kp TAB   &kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSPC
+                &kp TAB   &kp Q &kp W &kp E &kp R &tdrag MB1 T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSPC
                 &kp LCTRL &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
                 &kp LSHFT &kp Z &kp X &kp C &kp V &kp B   &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp ESC
                                 &kp LGUI &mo 1 &kp SPACE   &kp RET &mo 2 &kp RALT


### PR DESCRIPTION
Define a custom hold-tap (&tdrag): tap = T, hold (>200ms) = hold the left mouse button, enabling click-and-drag with the trackpad without sacrificing a key. Uses tap-preferred so fast typing of T never misfires into a drag. Adds the pointing.h include for the MB1 code; CONFIG_ZMK_POINTING is already enabled.